### PR TITLE
modified balances, verify_proof fails

### DIFF
--- a/zk_prover/src/merkle_sum_tree/mst.rs
+++ b/zk_prover/src/merkle_sum_tree/mst.rs
@@ -192,7 +192,13 @@ impl<const N_CURRENCIES: usize, const N_BYTES: usize> MerkleSumTree<N_CURRENCIES
 
             let mut hash_preimage = [Fp::zero(); N_CURRENCIES + 2];
             for (i, balance) in hash_preimage.iter_mut().enumerate().take(N_CURRENCIES) {
-                *balance = left_child.balances[i] + right_child.balances[i];
+                // *balance = left_child.balances[i] + right_child.balances[i];
+                //@change
+                if right_child.balances[i] > left_child.balances[i] {
+                    *balance = right_child.balances[i];
+                } else {
+                    *balance = left_child.balances[i];
+                }
             }
             hash_preimage[N_CURRENCIES] = left_child.hash;
             hash_preimage[N_CURRENCIES + 1] = right_child.hash;

--- a/zk_prover/src/merkle_sum_tree/node.rs
+++ b/zk_prover/src/merkle_sum_tree/node.rs
@@ -35,7 +35,13 @@ impl<const N_CURRENCIES: usize> Node<N_CURRENCIES> {
     {
         let mut hash_preimage = [Fp::zero(); N_CURRENCIES + 2];
         for (i, balance) in hash_preimage.iter_mut().enumerate().take(N_CURRENCIES) {
-            *balance = child_l.balances[i] + child_r.balances[i];
+            // *balance = child_l.balances[i] + child_r.balances[i];
+            //@change
+            if child_r.balances[i] > child_l.balances[i] {
+                *balance = child_r.balances[i];
+            } else {
+                *balance = child_l.balances[i];
+            }
         }
         hash_preimage[N_CURRENCIES] = child_l.hash;
         hash_preimage[N_CURRENCIES + 1] = child_r.hash;

--- a/zk_prover/src/merkle_sum_tree/tests.rs
+++ b/zk_prover/src/merkle_sum_tree/tests.rs
@@ -21,15 +21,17 @@ mod test {
         // expect root hash to be different than 0
         assert!(root.hash != 0.into());
         // expect balance to match the sum of all entries
-        assert!(root.balances == [556862.into(), 556862.into()]);
+        //@change - Trying to atack the total balance
+        // assert!(root.balances == [556862.into(), 556862.into()]);
         // expect depth to be 4
         assert!(*merkle_tree.depth() == 4_usize);
 
         // get proof for entry 0
-        let proof = merkle_tree.generate_proof(0).unwrap();
+        // let proof = merkle_tree.generate_proof(0).unwrap();
 
         // verify proof
-        assert!(merkle_tree.verify_proof(&proof));
+        //@change need to fix this
+        // assert!(merkle_tree.verify_proof(&proof));
 
         // Should generate different root hashes when changing the entry order
         let merkle_tree_2 =
@@ -38,32 +40,33 @@ mod test {
         assert_ne!(root.hash, merkle_tree_2.root().hash);
 
         // the balance total should be the same
+        //@change - Attack balance will differ if order is changed
         assert_eq!(root.balances, merkle_tree_2.root().balances);
 
-        // should create valid proof for each entry in the tree and verify it
-        for i in 0..=15 {
-            let proof = merkle_tree.generate_proof(i).unwrap();
-            assert!(merkle_tree.verify_proof(&proof));
-        }
+        // // should create valid proof for each entry in the tree and verify it
+        // for i in 0..=15 {
+        //     let proof = merkle_tree.generate_proof(i).unwrap();
+        //     assert!(merkle_tree.verify_proof(&proof));
+        // }
 
-        // shouldn't create a proof for an entry that doesn't exist in the tree
-        assert!(merkle_tree.generate_proof(16).is_err());
+        // // shouldn't create a proof for an entry that doesn't exist in the tree
+        // assert!(merkle_tree.generate_proof(16).is_err());
 
-        // shouldn't verify a proof with a wrong leaf
-        let invalid_entry = Entry::new(
-            "AtwIxZHo".to_string(),
-            [35479.to_biguint().unwrap(), 35479.to_biguint().unwrap()],
-        )
-        .unwrap();
-        let invalid_entry = invalid_entry;
-        let mut proof_invalid_1 = proof.clone();
-        proof_invalid_1.entry = invalid_entry;
-        assert!(!merkle_tree.verify_proof(&proof_invalid_1));
+        // // shouldn't verify a proof with a wrong leaf
+        // let invalid_entry = Entry::new(
+        //     "AtwIxZHo".to_string(),
+        //     [35479.to_biguint().unwrap(), 35479.to_biguint().unwrap()],
+        // )
+        // .unwrap();
+        // let invalid_entry = invalid_entry;
+        // let mut proof_invalid_1 = proof.clone();
+        // proof_invalid_1.entry = invalid_entry;
+        // assert!(!merkle_tree.verify_proof(&proof_invalid_1));
 
-        // shouldn't verify a proof with a wrong root hash
-        let mut proof_invalid_2 = proof.clone();
-        proof_invalid_2.root.hash = 0.into();
-        assert!(!merkle_tree.verify_proof(&proof_invalid_2));
+        // // shouldn't verify a proof with a wrong root hash
+        // let mut proof_invalid_2 = proof.clone();
+        // proof_invalid_2.root.hash = 0.into();
+        // assert!(!merkle_tree.verify_proof(&proof_invalid_2));
     }
 
     #[test]
@@ -217,14 +220,16 @@ mod test {
         // expect root hash to be different than 0
         assert!(root.hash != 0.into());
         // expect balance to match the sum of all entries
-        assert!(root.balances == [385969.into(), 459661.into()]);
+        //@change - Attack balance will differ from total balance
+        // assert!(root.balances == [385969.into(), 459661.into()]);
         // expect depth to be 4
         assert!(*merkle_tree.depth() == 4_usize);
 
         // should create valid proof for each entry in the tree and verify it
         for i in 0..=15 {
-            let proof = merkle_tree.generate_proof(i).unwrap();
-            assert!(merkle_tree.verify_proof(&proof));
+            // let proof = merkle_tree.generate_proof(i).unwrap();
+            // @change - Need to fix this
+            // assert!(merkle_tree.verify_proof(&proof));
         }
 
         // shouldn't create a proof for an entry that doesn't exist in the tree
@@ -249,14 +254,16 @@ mod test {
         // expect root hash to be different than 0
         assert!(root.hash != 0.into());
         // expect balance to match the sum of all entries
-        assert!(root.balances == [556863.into(), 556863.into()]);
+        //@change - Attack balance will differ from total balance
+        // assert!(root.balances == [556863.into(), 556863.into()]);
         // expect depth to be 5
         assert!(*merkle_tree.depth() == 5_usize);
 
         // should create valid proof for each entry in the tree and verify it
         for i in 0..=31 {
-            let proof = merkle_tree.generate_proof(i).unwrap();
-            assert!(merkle_tree.verify_proof(&proof));
+            // let proof = merkle_tree.generate_proof(i).unwrap();
+            // @change - Need to fix this
+            // assert!(merkle_tree.verify_proof(&proof));
         }
 
         // shouldn't create a proof for an entry that doesn't exist in the tree

--- a/zk_prover/src/merkle_sum_tree/tree.rs
+++ b/zk_prover/src/merkle_sum_tree/tree.rs
@@ -46,7 +46,13 @@ pub trait Tree<const N_CURRENCIES: usize, const N_BYTES: usize> {
 
         // for each balance in the left and right child, add them together and store in preimage
         for (i, balance) in preimage.iter_mut().enumerate().take(N_CURRENCIES) {
-            *balance = left_child.balances[i] + right_child.balances[i];
+            // *balance = left_child.balances[i] + right_child.balances[i];
+            //@change
+            if left_child.balances[i] > right_child.balances[i] {
+                *balance = left_child.balances[i];
+            } else {
+                *balance = right_child.balances[i];
+            }
         }
 
         // Add left and right child hashes to preimage

--- a/zk_prover/src/merkle_sum_tree/utils/build_tree.rs
+++ b/zk_prover/src/merkle_sum_tree/utils/build_tree.rs
@@ -85,8 +85,14 @@ where
             let mut hash_preimage = [Fp::zero(); N_CURRENCIES + 2];
 
             for (i, balance) in hash_preimage.iter_mut().enumerate().take(N_CURRENCIES) {
-                *balance =
-                    tree[level - 1][index].balances[i] + tree[level - 1][index + 1].balances[i];
+                // *balance =
+                //     tree[level - 1][index].balances[i] + tree[level - 1][index + 1].balances[i];
+                //@change
+                if tree[level - 1][index + 1].balances[i] > tree[level - 1][index].balances[i] {
+                    *balance = tree[level - 1][index + 1].balances[i];
+                } else {
+                    *balance = tree[level - 1][index].balances[i];
+                }
             }
 
             hash_preimage[N_CURRENCIES] = tree[level - 1][index].hash;


### PR DESCRIPTION
Modified the summa merkle tree such that it takes max of balances from child nodes instead of sum.

Currently the verify_proof function fails as generate_proof is unchanged. It has to be modified such that the sibiling leaf and middle node values have a `balance = max_balance - current_balance`

Because of these changes, all circuit tests fail because of the sum constraint in the MST chip. This is proof that summa's implementation is not vulnerable to the broken maxwell tree attack.